### PR TITLE
Add --txsizelimit flag to geth CLI that allows expansion of tran…

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -70,6 +70,7 @@ var (
 		utils.TxPoolNoLocalsFlag,
 		utils.TxPoolJournalFlag,
 		utils.TxPoolRejournalFlag,
+		utils.TxPoolSizeLimitFlag,
 		utils.TxPoolPriceLimitFlag,
 		utils.TxPoolPriceBumpFlag,
 		utils.TxPoolAccountSlotsFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -99,6 +99,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.TxPoolNoLocalsFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolRejournalFlag,
+			utils.TxPoolSizeLimitFlag,
 			utils.TxPoolPriceLimitFlag,
 			utils.TxPoolPriceBumpFlag,
 			utils.TxPoolAccountSlotsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -229,7 +229,7 @@ var (
 		Value: core.DefaultTxPoolConfig.Rejournal,
 	}
 	TxPoolSizeLimitFlag = cli.Uint64Flag{
-		Name:  "txpool.sizelimit",
+		Name:  "txsizelimit",
 		Usage: "Maximum size allowed for valid transaction (in KB)",
 		Value: 32,
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -228,6 +228,11 @@ var (
 		Usage: "Time interval to regenerate the local transaction journal",
 		Value: core.DefaultTxPoolConfig.Rejournal,
 	}
+	TxPoolSizeLimitFlag = cli.Uint64Flag{
+		Name:  "txpool.sizelimit",
+		Usage: "Maximum size allowed for valid transaction (in KB)",
+		Value: 32,
+	}
 	TxPoolPriceLimitFlag = cli.Uint64Flag{
 		Name:  "txpool.pricelimit",
 		Usage: "Minimum gas price limit to enforce for acceptance into the pool",
@@ -910,6 +915,9 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	}
 	if ctx.GlobalIsSet(TxPoolRejournalFlag.Name) {
 		cfg.Rejournal = ctx.GlobalDuration(TxPoolRejournalFlag.Name)
+	}
+	if ctx.GlobalIsSet(TxPoolSizeLimitFlag.Name) {
+		cfg.SizeLimit = ctx.GlobalUint64(TxPoolSizeLimitFlag.Name)
 	}
 	if ctx.GlobalIsSet(TxPoolPriceLimitFlag.Name) {
 		cfg.PriceLimit = ctx.GlobalUint64(TxPoolPriceLimitFlag.Name)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -125,6 +125,8 @@ type TxPoolConfig struct {
 	Journal   string        // Journal of local transactions to survive node restarts
 	Rejournal time.Duration // Time interval to regenerate the local transaction journal
 
+	SizeLimit uint64 // Maximum size allowed for valid transaction (in KB)
+
 	PriceLimit uint64 // Minimum gas price to enforce for acceptance into the pool
 	PriceBump  uint64 // Minimum price bump percentage to replace an already existing transaction (nonce)
 
@@ -141,6 +143,8 @@ type TxPoolConfig struct {
 var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
+
+	SizeLimit: 32,
 
 	PriceLimit: 1,
 	PriceBump:  10,
@@ -160,6 +164,10 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 	if conf.Rejournal < time.Second {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
 		conf.Rejournal = time.Second
+	}
+	if conf.SizeLimit < 32 {
+		log.Warn("Sanitizing invalid txpool size limit", "provided", conf.SizeLimit, "updated", DefaultTxPoolConfig.SizeLimit)
+		conf.SizeLimit = DefaultTxPoolConfig.SizeLimit
 	}
 	if conf.PriceLimit < 1 {
 		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultTxPoolConfig.PriceLimit)
@@ -557,8 +565,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if isQuorum && tx.GasPrice().Cmp(common.Big0) != 0 {
 		return ErrInvalidGasPrice
 	}
-	// Heuristic limit, reject transactions over 32KB to prevent DOS attacks
-	if tx.Size() > 32*1024 {
+	// Reject transactions over 32KB (or manually set limit) to prevent DOS attacks
+	if uint64(tx.Size()) > pool.config.SizeLimit*1024 {
 		return ErrOversizedData
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -259,13 +259,30 @@ func TestInvalidTransactions(t *testing.T) {
 		t.Error("expected", ErrOversizedData, "; got", err)
 	}
 
-	tx3, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(100), common.Big0, big.NewInt(0), nil), types.HomesteadSigner{}, key)
+	db, _ := ethdb.NewMemDatabase()
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	blockchain := &testBlockChain{statedb, big.NewInt(1000000), new(event.Feed)}
+	config := testTxPoolConfig
+	config.SizeLimit = 33
+	pool2 := NewTxPool(config, params.TestChainConfig, blockchain)
+	data2 := make([]byte, (33*1024)+1)
+	tx3, _ := types.SignTx(types.NewTransaction(2, common.Address{}, big.NewInt(100), big.NewInt(100000), big.NewInt(1), data2), types.HomesteadSigner{}, key)
+	if err := pool2.AddRemote(tx3); err != ErrOversizedData {
+		t.Error("expected", ErrOversizedData, "; got", err)
+	}
 
-	balance = new(big.Int).Add(tx3.Value(), new(big.Int).Mul(tx3.Gas(), tx3.GasPrice()))
-	from, _ = deriveSender(tx3)
+	config.SizeLimit = 34
+	pool3 := NewTxPool(config, params.TestChainConfig, blockchain)
+	if err := pool3.AddRemote(tx3); err != nil {
+		t.Error("expected error to be nil; got", err)
+	}
+
+	tx4, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(100), common.Big0, big.NewInt(0), nil), types.HomesteadSigner{}, key)
+	balance = new(big.Int).Add(tx4.Value(), new(big.Int).Mul(tx4.Gas(), tx4.GasPrice()))
+	from, _ = deriveSender(tx4)
 	pool.currentState.AddBalance(from, balance)
-	tx3.SetPrivate()
-	if err := pool.AddRemote(tx3); err != ErrEtherValueUnsupported {
+	tx4.SetPrivate()
+	if err := pool.AddRemote(tx4); err != ErrEtherValueUnsupported {
 		t.Error("expected", ErrEtherValueUnsupported, "; got", err)
 	}
 }

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -271,12 +271,6 @@ func TestInvalidTransactions(t *testing.T) {
 		t.Error("expected", ErrOversizedData, "; got", err)
 	}
 
-	config.SizeLimit = 34
-	pool3 := NewTxPool(config, params.TestChainConfig, blockchain)
-	if err := pool3.AddRemote(tx3); err != nil {
-		t.Error("expected error to be nil; got", err)
-	}
-
 	tx4, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(100), common.Big0, big.NewInt(0), nil), types.HomesteadSigner{}, key)
 	balance = new(big.Int).Add(tx4.Value(), new(big.Int).Mul(tx4.Gas(), tx4.GasPrice()))
 	from, _ = deriveSender(tx4)


### PR DESCRIPTION
## Overview
This PR introduces a transaction size limit flag `--txsizelimit` that extends the geth CLI within Quorum, effectively expanding the transaction size limit that is enforced in `tx_pool.go`

## Goal
Kaleido customers have requested the ability to increase the size limit on transactions accepted by the transaction pool. We will achieve this through the geth command line interface by adding an additional flag to set the txn size limit in KB (default=32). 

## Files changed
* `flags.go`:

  - defined a new flag under `vars`, called `TxPoolSizeLimitFlag` which is of type `cli.Uint64Flag` with initial value 32
  - alter `setTxPool` to check if the flag is set in the global context, and if so we pass it to the transaction pool config (`TxPoolConfig` type)

* `usage.go` & `main.go`:
  - register the new flag definition

* `tx_pool.go`:
  - define a `SizeLimit` field in `DefaultTxPoolConfig` with value 32
  - leverage the new `SizeLimit` field in `config.sanitize()` to protect against invalid argument set by user
  - finally, in `validateTx()` compare each incoming transaction's size to that set in the config ( `pool.config.SizeLimit` * 1024)


## Further Considerations
* should we enforce a maximum limit as well?
* should we check whether we are operating in a private node before enabling the flag? i.e. may be problematic for public node processing (DDOS attacks)