### PR TITLE
enforce maximum transaction size limit to 128KB; edit tests to reflec…

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -165,7 +165,7 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
 		conf.Rejournal = time.Second
 	}
-	if conf.SizeLimit < 32 {
+	if conf.SizeLimit < 32 || conf.SizeLimit > 128 {
 		log.Warn("Sanitizing invalid txpool size limit", "provided", conf.SizeLimit, "updated", DefaultTxPoolConfig.SizeLimit)
 		conf.SizeLimit = DefaultTxPoolConfig.SizeLimit
 	}
@@ -566,7 +566,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrInvalidGasPrice
 	}
 	// Reject transactions over 32KB (or manually set limit) to prevent DOS attacks
-	if uint64(tx.Size()) > pool.config.SizeLimit*1024 {
+	if float64(tx.Size()) > float64(pool.config.SizeLimit*1024) {
 		return ErrOversizedData
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -263,20 +263,28 @@ func TestInvalidTransactions(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, big.NewInt(1000000), new(event.Feed)}
 	config := testTxPoolConfig
-	config.SizeLimit = 33
+	config.SizeLimit = 128
 	pool2 := NewTxPool(config, params.TestChainConfig, blockchain)
-	data2 := make([]byte, (33*1024)+1)
+	pool2.currentState.AddBalance(from, big.NewInt(0xffffffffffffff))
+	data2 := make([]byte, (127 * 1024))
+
 	tx3, _ := types.SignTx(types.NewTransaction(2, common.Address{}, big.NewInt(100), big.NewInt(100000), big.NewInt(1), data2), types.HomesteadSigner{}, key)
-	if err := pool2.AddRemote(tx3); err != ErrOversizedData {
+	if err := pool2.AddRemote(tx3); err != ErrIntrinsicGas {
+		t.Error("expected", ErrIntrinsicGas, "; got", err)
+	}
+
+	data3 := make([]byte, (128*1024)+1)
+	tx4, _ := types.SignTx(types.NewTransaction(2, common.Address{}, big.NewInt(100), big.NewInt(100000), big.NewInt(1), data3), types.HomesteadSigner{}, key)
+	if err := pool2.AddRemote(tx4); err != ErrOversizedData {
 		t.Error("expected", ErrOversizedData, "; got", err)
 	}
 
-	tx4, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(100), common.Big0, big.NewInt(0), nil), types.HomesteadSigner{}, key)
-	balance = new(big.Int).Add(tx4.Value(), new(big.Int).Mul(tx4.Gas(), tx4.GasPrice()))
-	from, _ = deriveSender(tx4)
+	tx5, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(100), common.Big0, big.NewInt(0), nil), types.HomesteadSigner{}, key)
+	balance = new(big.Int).Add(tx5.Value(), new(big.Int).Mul(tx5.Gas(), tx5.GasPrice()))
+	from, _ = deriveSender(tx5)
 	pool.currentState.AddBalance(from, balance)
-	tx4.SetPrivate()
-	if err := pool.AddRemote(tx4); err != ErrEtherValueUnsupported {
+	tx5.SetPrivate()
+	if err := pool.AddRemote(tx5); err != ErrEtherValueUnsupported {
 		t.Error("expected", ErrEtherValueUnsupported, "; got", err)
 	}
 }


### PR DESCRIPTION
Upon further consideration, we are going to enforce a max on the `tx_size_limit` flag at 128KB. 

Notes:
* We may increase the max in the future, but we want to get this testing on our system asap to understand the effects
* We want to get a PR out to main Quorum so we can get backing for this change before submitting a PR to geth. This is crucial because if we allow large transactions in Kaleido while the geth community still enforces a max, we are on the path to a permanent fork from geth === bad