### PR TITLE
Remove txsizelimit debuglogs

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -70,7 +70,6 @@ var (
 		utils.TxPoolNoLocalsFlag,
 		utils.TxPoolJournalFlag,
 		utils.TxPoolRejournalFlag,
-		utils.TxPoolSizeLimitFlag,
 		utils.TxPoolPriceLimitFlag,
 		utils.TxPoolPriceBumpFlag,
 		utils.TxPoolAccountSlotsFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -99,7 +99,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.TxPoolNoLocalsFlag,
 			utils.TxPoolJournalFlag,
 			utils.TxPoolRejournalFlag,
-			utils.TxPoolSizeLimitFlag,
 			utils.TxPoolPriceLimitFlag,
 			utils.TxPoolPriceBumpFlag,
 			utils.TxPoolAccountSlotsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -228,11 +228,6 @@ var (
 		Usage: "Time interval to regenerate the local transaction journal",
 		Value: core.DefaultTxPoolConfig.Rejournal,
 	}
-	TxPoolSizeLimitFlag = cli.Uint64Flag{
-		Name:  "txsizelimit",
-		Usage: "Maximum size allowed for valid transaction (in KB)",
-		Value: 32,
-	}
 	TxPoolPriceLimitFlag = cli.Uint64Flag{
 		Name:  "txpool.pricelimit",
 		Usage: "Minimum gas price limit to enforce for acceptance into the pool",
@@ -915,9 +910,6 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	}
 	if ctx.GlobalIsSet(TxPoolRejournalFlag.Name) {
 		cfg.Rejournal = ctx.GlobalDuration(TxPoolRejournalFlag.Name)
-	}
-	if ctx.GlobalIsSet(TxPoolSizeLimitFlag.Name) {
-		cfg.SizeLimit = ctx.GlobalUint64(TxPoolSizeLimitFlag.Name)
 	}
 	if ctx.GlobalIsSet(TxPoolPriceLimitFlag.Name) {
 		cfg.PriceLimit = ctx.GlobalUint64(TxPoolPriceLimitFlag.Name)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -125,8 +125,6 @@ type TxPoolConfig struct {
 	Journal   string        // Journal of local transactions to survive node restarts
 	Rejournal time.Duration // Time interval to regenerate the local transaction journal
 
-	SizeLimit uint64 // Maximum size allowed for valid transaction (in KB)
-
 	PriceLimit uint64 // Minimum gas price to enforce for acceptance into the pool
 	PriceBump  uint64 // Minimum price bump percentage to replace an already existing transaction (nonce)
 
@@ -143,8 +141,6 @@ type TxPoolConfig struct {
 var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
-
-	SizeLimit: 32,
 
 	PriceLimit: 1,
 	PriceBump:  10,
@@ -164,10 +160,6 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 	if conf.Rejournal < time.Second {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
 		conf.Rejournal = time.Second
-	}
-	if conf.SizeLimit < 32 {
-		log.Warn("Sanitizing invalid txpool size limit", "provided", conf.SizeLimit, "updated", DefaultTxPoolConfig.SizeLimit)
-		conf.SizeLimit = DefaultTxPoolConfig.SizeLimit
 	}
 	if conf.PriceLimit < 1 {
 		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultTxPoolConfig.PriceLimit)
@@ -565,8 +557,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if isQuorum && tx.GasPrice().Cmp(common.Big0) != 0 {
 		return ErrInvalidGasPrice
 	}
-	// Reject transactions over 32KB (or manually set limit) to prevent DOS attacks
-	if uint64(tx.Size()) > pool.config.SizeLimit*1024 {
+	// Heuristic limit, reject transactions over 32KB to prevent DOS attacks
+	if tx.Size() > 32*1024 {
 		return ErrOversizedData
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -259,24 +259,13 @@ func TestInvalidTransactions(t *testing.T) {
 		t.Error("expected", ErrOversizedData, "; got", err)
 	}
 
-	db, _ := ethdb.NewMemDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
-	blockchain := &testBlockChain{statedb, big.NewInt(1000000), new(event.Feed)}
-	config := testTxPoolConfig
-	config.SizeLimit = 33
-	pool2 := NewTxPool(config, params.TestChainConfig, blockchain)
-	data2 := make([]byte, (33*1024)+1)
-	tx3, _ := types.SignTx(types.NewTransaction(2, common.Address{}, big.NewInt(100), big.NewInt(100000), big.NewInt(1), data2), types.HomesteadSigner{}, key)
-	if err := pool2.AddRemote(tx3); err != ErrOversizedData {
-		t.Error("expected", ErrOversizedData, "; got", err)
-	}
+	tx3, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(100), common.Big0, big.NewInt(0), nil), types.HomesteadSigner{}, key)
 
-	tx4, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(100), common.Big0, big.NewInt(0), nil), types.HomesteadSigner{}, key)
-	balance = new(big.Int).Add(tx4.Value(), new(big.Int).Mul(tx4.Gas(), tx4.GasPrice()))
-	from, _ = deriveSender(tx4)
+	balance = new(big.Int).Add(tx3.Value(), new(big.Int).Mul(tx3.Gas(), tx3.GasPrice()))
+	from, _ = deriveSender(tx3)
 	pool.currentState.AddBalance(from, balance)
-	tx4.SetPrivate()
-	if err := pool.AddRemote(tx4); err != ErrEtherValueUnsupported {
+	tx3.SetPrivate()
+	if err := pool.AddRemote(tx3); err != ErrEtherValueUnsupported {
 		t.Error("expected", ErrEtherValueUnsupported, "; got", err)
 	}
 }

--- a/p2p/permissions.go
+++ b/p2p/permissions.go
@@ -24,14 +24,14 @@ func isNodePermissioned(nodename string, currentNode string, datadir string, dir
 		permissionedList = append(permissionedList, v.ID.String())
 	}
 
-	log.Debug("isNodePermissioned", "permissionedList", permissionedList)
+	// log.Debug("isNodePermissioned", "permissionedList", permissionedList)
 	for _, v := range permissionedList {
 		if v == nodename {
 			log.Debug("isNodePermissioned", "connection", direction, "nodename", nodename, "ALLOWED-BY", currentNode)
 			return true
 		}
 	}
-	log.Debug("isNodePermissioned", "connection", direction, "nodename", nodename, "DENIED-BY", currentNode)
+	// log.Debug("isNodePermissioned", "connection", direction, "nodename", nodename, "DENIED-BY", currentNode)
 	return false
 }
 
@@ -73,6 +73,5 @@ func parsePermissionedNodes(DataDir string) []*discover.Node {
 		}
 		nodes = append(nodes, node)
 	}
-	log.Debug("parsePermissionedNodes", "permissionedNodeList", nodes)
 	return nodes
 }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -723,17 +723,17 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Nod
 	//START - QUORUM Permissioning
 	currentNode := srv.NodeInfo().ID
 	cnodeName := srv.NodeInfo().Name
-	log.Debug("Quorum permissioning",
-		"EnableNodePermission", srv.EnableNodePermission,
-		"DataDir", srv.DataDir,
-		"Current Node ID", currentNode,
-		"Node Name", cnodeName,
-		"Dialed Dest", dialDest,
-		"Connection ID", c.id,
-		"Connection String", c.id.String())
+	// log.Debug("Quorum permissioning",
+	// 	"EnableNodePermission", srv.EnableNodePermission,
+	// 	"DataDir", srv.DataDir,
+	// 	"Current Node ID", currentNode,
+	// 	"Node Name", cnodeName,
+	// 	"Dialed Dest", dialDest,
+	// 	"Connection ID", c.id,
+	// 	"Connection String", c.id.String())
 
 	if srv.EnableNodePermission {
-		log.Debug("Node Permissioning is Enabled.")
+		// log.Debug("Node Permissioning is Enabled.")
 		node := c.id.String()
 		direction := "INCOMING"
 		if dialDest != nil {


### PR DESCRIPTION
* Reverts changes to `txsizelimit`
* Removes some debug logs in quorum to avoid hogging geth.log disk usage