### PR TITLE
Kaleido quorum fixes on Quorum 2.2.3

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -153,7 +153,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	TransactionSizeLimit: 64,
+	TransactionSizeLimit: 128,
 
 	PriceLimit: 1,
 	PriceBump:  10,

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -401,10 +402,14 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 	// Initialize a price based heap with the head transactions
 	heads := make(TxByPrice, 0, len(txs))
 	for from, accTxs := range txs {
-		heads = append(heads, accTxs[0])
 		// Ensure the sender address is from the signer
-		acc, _ := Sender(signer, accTxs[0])
-		txs[acc] = accTxs[1:]
+		acc, err := Sender(signer, accTxs[0])
+		if (err == nil) {
+			heads = append(heads, accTxs[0])
+			txs[acc] = accTxs[1:]
+		} else {
+			log.Info("Failed to recovered sender address, this transaction is skipped", "from", from, "nonce", accTxs[0].data.AccountNonce, "err", err)
+		}
 		if from != acc {
 			delete(txs, from)
 		}


### PR DESCRIPTION
Creating this PR to show the two fixes we need ported on Quorum 2.2.3 to remain in sync with what was delivered in Kaleido node software 1.0.10 and 0.1.501 (both of which are deployed in multiple customer environments).

#20
#22

#22 is a custom code change. #20 should be available in master once we upgrade to the next version of quorum