### PR TITLE
attempted fix for ibft failure: 2f+1 ===>  N-f

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -141,6 +141,7 @@ var (
 		utils.EmitCheckpointsFlag,
 		utils.IstanbulRequestTimeoutFlag,
 		utils.IstanbulBlockPeriodFlag,
+		utils.IstanbulQuorumFormulaFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -278,6 +278,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.IstanbulRequestTimeoutFlag,
 			utils.IstanbulBlockPeriodFlag,
+			utils.IstanbulQuorumFormulaFlag,
 		},
 	},
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -618,6 +618,11 @@ var (
 		Usage: "Default minimum difference between two consecutive block's timestamps in seconds",
 		Value: eth.DefaultConfig.Istanbul.BlockPeriod,
 	}
+	IstanbulQuorumFormulaFlag = cli.Uint64Flag{
+		Name: "istanbul.quorumformula",
+		Usage: "Formula used for calculating quorum, 0 ==> 2f+1, 1 ==> Ceil(2N/3), 2 ==> N-f",
+		Value: eth.DefaultConfig.Istanbul.QuorumFormula,
+	}
 
 	// Metrics flags
 	MetricsEnabledFlag = cli.BoolFlag{
@@ -1125,6 +1130,9 @@ func setIstanbul(ctx *cli.Context, cfg *eth.Config) {
 	}
 	if ctx.GlobalIsSet(IstanbulBlockPeriodFlag.Name) {
 		cfg.Istanbul.BlockPeriod = ctx.GlobalUint64(IstanbulBlockPeriodFlag.Name)
+	}
+	if ctx.GlobalIsSet(IstanbulQuorumFormulaFlag.Name) {
+		cfg.Istanbul.QuorumFormula = ctx.GlobalUint64(IstanbulQuorumFormulaFlag.Name)
 	}
 }
 

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	BlockPeriod    uint64         `toml:",omitempty"` // Default minimum difference between two consecutive block's timestamps in second
 	ProposerPolicy ProposerPolicy `toml:",omitempty"` // The policy for proposer selection
 	Epoch          uint64         `toml:",omitempty"` // The number of blocks after which to checkpoint and reset the pending votes
+	QuorumFormula   uint64         `toml:",omitempty"` // The quorum formula used, 0 ==> 2f+1, 1 ==> Ceil(2N/3), 2 ==> N-f
 }
 
 var DefaultConfig = &Config{
@@ -35,4 +36,5 @@ var DefaultConfig = &Config{
 	BlockPeriod:    1,
 	ProposerPolicy: RoundRobin,
 	Epoch:          30000,
+	QuorumFormula:    1,
 }

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -36,5 +36,5 @@ var DefaultConfig = &Config{
 	BlockPeriod:    1,
 	ProposerPolicy: RoundRobin,
 	Epoch:          30000,
-	QuorumFormula:    1,
+	QuorumFormula:    0,
 }

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -114,7 +114,6 @@ func (c *core) finalizeMessage(msg *message) ([]byte, error) {
 			return nil, err
 		}
 	}
-
 	// Sign message
 	data, err := msg.PayloadNoSig()
 	if err != nil {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -101,7 +101,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 			c.sendRoundChange(roundView.Round)
 		}
 		return nil
-	} else if num == int(2*c.valSet.F()+1) && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {
+	} else if num == int(c.valSet.Size()-c.valSet.F()) && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {
 		// We've received 2f+1 ROUND CHANGE messages, start a new round immediately.
 		logger.Info(fmt.Sprintf("====>Starting New round after 2f+1 messages: new round - %v, seq - %v", roundView.Round, c.current.Sequence()))
 		c.startNewRound(roundView.Round)

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -91,7 +91,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 		return err
 	}
 
-	logger.Debug(fmt.Sprintf("=====> Handling round change msg, current round: %v, current sequence: %v, total number of round change msg for the round %v, sequence %v, is %v, waiting for round change? %v, current F() is %v", cv.Round, cv.Sequence, roundView.Round, roundView.Sequence, num, c.waitingForRoundChange, c.valSet.F()))
+	logger.Debug(fmt.Sprintf("=====> Handling round change msg, current round: %v, current sequence: %v, total number of round change msg for the round %v, sequence %v, is %v, waiting for round change? %v, current F() is %v, quorum formula is %v, quorum is %v", cv.Round, cv.Sequence, roundView.Round, roundView.Sequence, num, c.waitingForRoundChange, c.valSet.F(), c.config.QuorumFormula, c.valSet.QuorumSize(c.config.QuorumFormula)))
 	// Once we received f+1 ROUND CHANGE messages, those messages form a weak certificate.
 	// If our round number is smaller than the certificate's round number, we would
 	// try to catch up the round number.
@@ -101,7 +101,7 @@ func (c *core) handleRoundChange(msg *message, src istanbul.Validator) error {
 			c.sendRoundChange(roundView.Round)
 		}
 		return nil
-	} else if num == int(c.valSet.Size()-c.valSet.F()) && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {
+	} else if num == c.valSet.QuorumSize(c.config.QuorumFormula) && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {
 		// We've received 2f+1 ROUND CHANGE messages, start a new round immediately.
 		logger.Info(fmt.Sprintf("====>Starting New round after 2f+1 messages: new round - %v, seq - %v", roundView.Round, c.current.Sequence()))
 		c.startNewRound(roundView.Round)

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -73,6 +73,8 @@ type ValidatorSet interface {
 	F() int
 	// Get proposer policy
 	Policy() ProposerPolicy
+	// Get Quorum size based on formula
+	QuorumSize(uint64) int
 }
 
 // ----------------------------------------------------------------------------

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -68,9 +68,9 @@ func newDefaultSet(addrs []common.Address, policy istanbul.ProposerPolicy) *defa
 	if policy == istanbul.Sticky {
 		valSet.selector = stickyProposer
 	}
-
 	return valSet
 }
+
 
 func (valSet *defaultSet) Size() int {
 	valSet.validatorMu.RLock()
@@ -199,3 +199,13 @@ func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
 func (valSet *defaultSet) F() int { return int(math.Ceil(float64(valSet.Size())/3)) - 1 }
 
 func (valSet *defaultSet) Policy() istanbul.ProposerPolicy { return valSet.policy }
+
+func (valSet *defaultSet) QuorumSize(formulaType uint64) int {
+	if formulaType == 1 {
+		return int(math.Ceil(float64(2*valSet.Size()/3)))
+	} else if formulaType == 2 {
+		return int(valSet.Size()-valSet.F())
+	} else {
+		return int(2*valSet.F()+1)
+	}
+}


### PR DESCRIPTION
Logs showed evidence that, for f=0, N=2, 2 round change messages should start next round. but with 2f+1, condition is not met. changing 2f+1 to N-f , should not have any side effects.

--edit--
More information on the failure scenario. The issue happens when nodes are trying scale out the validator set by voting them in one by one . Most common scenario for failure case is when validator set size is two and one of the validator triggers round change. Expected behavior is that validator nodes start the new round and one of them (current proposer) proposes either the locked block or pendingRequest and eventually commit a block. 
Instead there is a liveness failure, where validators nodes keep timing out on roundchange timeout without any proposal being made.
After adding some useful logging statements, main cause seems to be that neither of nodes start new round even after receiving roundchange message from each other, which is done in function handleRoundChange in roundchange.go file.  

https://github.com/kaleido-io/quorum/blob/d715db38c4bf20d67e0991da2ea916455343df48/consensus/istanbul/core/roundchange.go#L93-L109

the 'else if' part is never executed when valSet.Size() = 2 and valSet.F() = 0 and num = 1 or 2.
Nodes do receive 2f+1 roundchange messages but never execute startNewRound. As a result they keep timing out with valSet remaining unchanged and this keep repeating without any progress.

Logs for 4 node ibft run with helpful print statement  is attached. [27728.zip](https://github.com/kaleido-io/quorum/files/3447934/27728.zip)
