### PR TITLE
fixed quorum size formula for Ceil(2N/3)

### DIFF
--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -202,7 +202,7 @@ func (valSet *defaultSet) Policy() istanbul.ProposerPolicy { return valSet.polic
 
 func (valSet *defaultSet) QuorumSize(formulaType uint64) int {
 	if formulaType == 1 {
-		return int(math.Ceil(float64(2*valSet.Size()/3)))
+		return int(math.Ceil(float64(2*valSet.Size())/3))
 	} else if formulaType == 2 {
 		return int(valSet.Size()-valSet.F())
 	} else {


### PR DESCRIPTION
int(math.Ceil(float64(2valSet.Size()/3)))
to
int(math.Ceil(float64(2valSet.Size())/3))

was resulting in wrong values for quorum sizes.

for example,   N=4, quorum size was coming out to be 2, instead of expected 3 in previous version. 